### PR TITLE
Fix: installer to use latest release; release artifact names changed algorun->nodekit

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -24,11 +24,11 @@ jobs:
           GOOS: ${{matrix.goos}}
           GOARCH: ${{matrix.goarch}}
           CGO_ENABLED: 0
-        run: go build -o bin/algorun-${{matrix.goarch}}-${{matrix.goos}} *.go
+        run: go build -o bin/nodekit-${{matrix.goarch}}-${{matrix.goos}} *.go
       - uses: actions/upload-artifact@master
         with:
-          name: algorun-${{matrix.goarch}}-${{matrix.goos}}
-          path: bin/algorun-${{matrix.goarch}}-${{matrix.goos}}
+          name: nodekit-${{matrix.goarch}}-${{matrix.goos}}
+          path: bin/nodekit-${{matrix.goarch}}-${{matrix.goos}}
   release:
     needs: 
       - build
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          pattern: algorun*
+          pattern: nodekit*
           path: ./bin
       - uses: go-semantic-release/action@v1
         name: release

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-
-
 BANNER='   _____  .__                __________
    /  _  \ |  |    ____   ____\______   \__ __  ____
   /  /_\  \|  |   / ___\ /  _ \|       _/  |  \/    \
@@ -12,8 +10,7 @@ BANNER='   _____  .__                __________
          \/     /_____/               \/           \/ '
   
 os=$(uname -ms)
-release="https://github.com/algorandfoundation/nodekit/releases/download"
-version="v1.0.0-beta.5"
+release="https://github.com/algorandfoundation/nodekit/releases/latest/download"
 
 Red=''
 Green=''
@@ -67,29 +64,34 @@ trap "info Exiting the installation" exit
 
 case $os in
 'Darwin x86_64')
-    target=nodekit-amd64-darwin
+    platform=amd64-darwin
+    target=nodekit-$platform
     ;;
 'Darwin arm64')
-    target=nodekit-arm64-darwin
+    platform=arm64-darwin
+    target=nodekit-$platform
     ;;
 'Linux aarch64' | 'Linux arm64')
-    target=nodekit-arm64-linux
+    platform=arm64-linux
+    target=nodekit-$platform
     ;;
 'Linux x86_64' | *)
-    target=nodekit-amd64-linux
+    platform=amd64-linux
+    target=nodekit-$platform
     ;;
 esac
  
-echo -e "${Opaque}Downloading:${Reset}${Bold_White} $target $version${Reset}"
-curl --fail --location --progress-bar --output nodekit "$release/$version/$target" ||
-  error "Failed to download ${target} from ${release}"
+url="$release/$target"
+echo -e "${Opaque}Downloading:${Reset}${Bold_White} $target ${Reset}from $url"
+curl --fail --location --progress-bar --output nodekit "$url" ||
+  error "Failed to download ${target} from ${release} ${url}"
 
 chmod +x nodekit
 
 trap - int
 trap - exit
 
-success "Downloaded: ${Bold_Green}nodekit ${version} 🎉${Reset}"
+success "Downloaded: ${Bold_Green}${target} as nodekit 🎉${Reset}"
 info "Explore all nodekit options with:"
 echo "./nodekit --help"
 echo ""


### PR DESCRIPTION
# ℹ Overview

- install.sh uses /latest/ stable release
- release artifacts were named algorun, renamed them to nodekit