### PR TITLE
Fix/bootstrap waiting after questions

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -40,7 +40,7 @@ var bootstrapCmdLong = lipgloss.JoinVertical(
 
 var tutorial = `# Welcome!
 
-This is the beginning of your adventure into running the an Algorand node!
+This is the beginning of your adventure into running an Algorand node!
 
 `
 

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/algorandfoundation/nodekit/api"
 	cmdutils "github.com/algorandfoundation/nodekit/cmd/utils"
 	"github.com/algorandfoundation/nodekit/cmd/utils/explanations"
@@ -18,7 +20,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 // bootstrapCmdShort provides a brief description of the "bootstrap" command to initialize a fresh Algorand node.
@@ -84,23 +85,36 @@ var bootstrapCmd = &cobra.Command{
 		if _, err := p.Run(); err != nil {
 			log.Fatal(err)
 		}
+
 		if msg == nil {
 			return nil
 		}
 
-		log.Warn(style.Yellow.Render(explanations.SudoWarningMsg))
-		if msg.Install && !algod.IsInstalled() {
+		if msg.Install {
+			log.Warn(style.Yellow.Render(explanations.SudoWarningMsg))
+
 			err := algod.Install()
 			if err != nil {
 				return err
 			}
-		}
 
-		// Wait for algod
-		time.Sleep(10 * time.Second)
+			// Wait for algod
+			time.Sleep(10 * time.Second)
 
-		if !algod.IsRunning() {
-			log.Fatal("algod is not running")
+			if !algod.IsRunning() {
+				log.Fatal("algod is not running. Something went wrong with installation")
+			}
+		} else {
+			if !algod.IsRunning() {
+				log.Info(style.Green.Render("Starting Algod 🚀"))
+				log.Warn(style.Yellow.Render(explanations.SudoWarningMsg))
+				err := algod.Start()
+				if err != nil {
+					log.Fatal(err)
+				}
+				log.Info(style.Green.Render("Algorand started successfully 🎉"))
+				time.Sleep(2 * time.Second)
+			}
 		}
 
 		dataDir, err := algod.GetDataDir("")
@@ -114,7 +128,6 @@ var bootstrapCmd = &cobra.Command{
 		}
 
 		if msg.Catchup {
-
 			network, err := utils.GetNetworkFromDataDir(dataDir)
 			if err != nil {
 				return err

--- a/ui/bootstrap/model.go
+++ b/ui/bootstrap/model.go
@@ -76,7 +76,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case CatchupQuestion:
 					m.Question = WaitingQuestion
 					m.BootstrapMsg.Catchup = false
-					return m, tea.Sequence(m.Outside.Emit(m.BootstrapMsg), tea.Quit)
+					return m, app.EmitBootstrapSelection(app.BoostrapSelected(m.BootstrapMsg))
 				}
 			}
 

--- a/ui/bootstrap/model.go
+++ b/ui/bootstrap/model.go
@@ -66,7 +66,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.Question = WaitingQuestion
 					return m, app.EmitBootstrapSelection(app.BoostrapSelected(m.BootstrapMsg))
 				}
-
 			}
 		case "n":
 			{
@@ -77,10 +76,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case CatchupQuestion:
 					m.Question = WaitingQuestion
 					m.BootstrapMsg.Catchup = false
-				case WaitingQuestion:
 					return m, tea.Sequence(m.Outside.Emit(m.BootstrapMsg), tea.Quit)
 				}
-
 			}
 
 		case "ctrl+c", "esc", "q":


### PR DESCRIPTION
# ℹ Overview

- fix typo
- fixed bug bootstrap sub-program that prompts
    - seemed to hang after the catchup question but was in fact waiting for more input
    - now returning after catchup question
-  change install/not install logic
    -  wait for algod only when installing
    - attempt to launch algod if we are not installing and it is not running