### PR TITLE
Fix: Replace curl with wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ nodekit [flags]
 Connect to your server and run the installation script which will bootstrap your node.
 
 ```bash
-curl -fsSL https://nodekit.run/install.sh | bash
+wget -qO- https://nodekit.run/install.sh | bash
 ```

--- a/assets/footer.md
+++ b/assets/footer.md
@@ -3,5 +3,5 @@
 Connect to your server and run the installation script which will bootstrap your node.
 
 ```bash
-curl -fsSL https://nodekit.run/install.sh | bash
+wget -qO- https://nodekit.run/install.sh | bash
 ```

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -17,7 +17,7 @@ NodeKit can help you with:
 To get started with NodeKit, copy-paste this command in your terminal:
 
 ```bash
-curl -fsSL https://nodekit.run/install.sh | bash
+wget -qO- https://nodekit.run/install.sh | bash
 ```
 
 This will detect your operating system and download the appropriate NodeKit executable to your local directory.

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -104,7 +104,7 @@ export const lang = "en";
                     >
                         <Code
                             lang="shell"
-                            code={`curl -fsSL https://nodekit.run/install.sh | bash`}
+                            code={`wget -qO- https://nodekit.run/install.sh | bash`}
                             class="max-w-full z-10"
                         />
                         <a


### PR DESCRIPTION
# ℹ Overview

Fresh ubuntu LTS installs do not ship with `curl`, but they do ship with `wget`. Users have reported having to debug why the `curl` installation command fails.
Replacing `curl` with `wget` to improve the onboarding experience. 

- Replacing `curl` with `wget` in the install command
- Intentionally leaving `curl` in `internal/algod/linux/linux.go` as it is installed by that point

### 📝 Related Issues

- resolves #73

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Pre-commit checks pass
- [ ] Check that this works on mac OS