### PR TITLE
Fix: error during first participation key generation

### DIFF
--- a/internal/algod/participation/participation.go
+++ b/internal/algod/participation/participation.go
@@ -83,8 +83,11 @@ func GenerateKeys(
 			return nil, context.Canceled
 		case <-time.After(2 * time.Second):
 			partKeys, _, err := GetList(ctx, client)
-			if partKeys == nil || err != nil {
-				return nil, errors.New("failed to get participation keys")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get participation keys: %s", err)
+			}
+			if partKeys == nil {
+				continue
 			}
 			for _, k := range partKeys {
 				if k.Address == address &&


### PR DESCRIPTION
# ℹ Overview

algod /v2/participation returns `nil` when there are no participation keys registered. Our code was assuming `[]`, resulting in `failed to get participation keys` error messages for users creating their first participation key

This was missedbecause the keys we tested with were too short, and they had completed already by the time the check was done

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [ ] Pre-commit checks pass