### PR TITLE
Fix: install.sh to test for curl, otherwise use wget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,8 +88,12 @@ target="nodekit-$platform"
 url="$release/$target"
 
 echo -e "${Opaque}Downloading:${Reset}${Bold_White} $target ${Reset}from $url"
-curl --fail --location --progress-bar --output nodekit "$url" ||
-error "Failed to download ${target} from ${release} ${url}"
+errormessage="Failed to download ${target} from ${release} ${url}"
+if curl --version > /dev/null 2>&1; then
+  curl --fail --location --progress-bar --output nodekit "$url" || error "$errormessage"
+else
+  wget -qO nodekit --show-progress "$url" || error "$errormessage"
+fi
 
 chmod +x nodekit
 


### PR DESCRIPTION
# ℹ Overview

We offer wget as an install command, but install.sh was still using curl internally. Fixed it to fall back to wget if curl is not available

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Pre-commit checks pass