### PR TITLE
fix: improve command error handling

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"github.com/algorandfoundation/nodekit/api"
 	"github.com/algorandfoundation/nodekit/cmd/utils/explanations"
 	"github.com/algorandfoundation/nodekit/internal/algod"
@@ -20,8 +21,7 @@ func WithInvalidResponsesExplanations(err error, response api.ResponseInterface,
 	}
 	if response.StatusCode() > 300 {
 		log.Fatal(
-			style.Red.Render("failed to get status: error code %d")+"\n\n"+explanations.TokenNotAdmin+"\n"+postFix,
-			response.StatusCode())
+			style.Red.Render(fmt.Sprintf("failed to get status: error code %d", response.StatusCode())) + "\n\n" + explanations.TokenNotAdmin + "\n" + postFix)
 	}
 }
 


### PR DESCRIPTION
# ℹ Overview

- cleans up command outputs for command runner
- organizes friendly error at the end of command output
- handles multiple error types gracefully

### 📝 Related Issues

- resolves #106

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [X] Pre-commit checks pass