### PR TITLE
Fix: participation key rendering from base64url to base64

### DIFF
--- a/ui/modal/testdata/Test_Snapshot/InfoModal.golden
+++ b/ui/modal/testdata/Test_Snapshot/InfoModal.golden
@@ -31,20 +31,20 @@
                                                                                 
                                                                                 
                                                                                 
-                         ╭──Key Information────────────╮                        
-                         │                             │                        
-                         │ Account: ABC                │                        
-                         │ Participation ID: 123       │                        
-                         │                             │                        
-                         │ Vote Key: VEVTVEtFWQ        │                        
-                         │ Selection Key: VEVTVEtFWQ   │                        
-                         │ State Proof Key: VEVTVEtFWQ │                        
-                         │                             │                        
-                         │ Vote First Valid: 0         │                        
-                         │ Vote Last Valid: 30000      │                        
-                         │ Vote Key Dilution: 100      │                        
-                         │                             │                        
-                         ╰──( (d)elete | (o)nline )────╯                        
+                        ╭──Key Information──────────────╮                       
+                        │                               │                       
+                        │ Account: ABC                  │                       
+                        │ Participation ID: 123         │                       
+                        │                               │                       
+                        │ Vote Key: VEVTVEtFWQ==        │                       
+                        │ Selection Key: VEVTVEtFWQ==   │                       
+                        │ State Proof Key: VEVTVEtFWQ== │                       
+                        │                               │                       
+                        │ Vote First Valid: 0           │                       
+                        │ Vote Last Valid: 30000        │                       
+                        │ Vote Key Dilution: 100        │                       
+                        │                               │                       
+                        ╰────( (d)elete | (o)nline )────╯                       
                                                                                 
                                                                                 
                                                                                 

--- a/ui/modals/info/info.go
+++ b/ui/modals/info/info.go
@@ -92,9 +92,9 @@ func (m ViewModel) View() string {
 	}
 	account := style.Cyan.Render("Account: ") + m.Participation.Address
 	id := style.Cyan.Render("Participation ID: ") + m.Participation.Id
-	selection := style.Yellow.Render("Selection Key: ") + *utils.UrlEncodeBytesPtrOrNil(m.Participation.Key.SelectionParticipationKey[:])
-	vote := style.Yellow.Render("Vote Key: ") + *utils.UrlEncodeBytesPtrOrNil(m.Participation.Key.VoteParticipationKey[:])
-	stateProof := style.Yellow.Render("State Proof Key: ") + *utils.UrlEncodeBytesPtrOrNil(*m.Participation.Key.StateProofKey)
+	selection := style.Yellow.Render("Selection Key: ") + *utils.Base64EncodeBytesPtrOrNil(m.Participation.Key.SelectionParticipationKey[:])
+	vote := style.Yellow.Render("Vote Key: ") + *utils.Base64EncodeBytesPtrOrNil(m.Participation.Key.VoteParticipationKey[:])
+	stateProof := style.Yellow.Render("State Proof Key: ") + *utils.Base64EncodeBytesPtrOrNil(*m.Participation.Key.StateProofKey)
 	voteFirstValid := style.Purple("Vote First Valid: ") + utils.IntToStr(m.Participation.Key.VoteFirstValid)
 	voteLastValid := style.Purple("Vote Last Valid: ") + utils.IntToStr(m.Participation.Key.VoteLastValid)
 	voteKeyDilution := style.Purple("Vote Key Dilution: ") + utils.IntToStr(m.Participation.Key.VoteKeyDilution)

--- a/ui/modals/info/testdata/Test_Snapshot/Visible.golden
+++ b/ui/modals/info/testdata/Test_Snapshot/Visible.golden
@@ -1,12 +1,12 @@
-                           
-Account: ABC               
-Participation ID: 123      
-                           
-Vote Key: VEVTVEtFWQ       
-Selection Key: VEVTVEtFWQ  
-State Proof Key: VEVTVEtFWQ
-                           
-Vote First Valid: 0        
-Vote Last Valid: 30000     
-Vote Key Dilution: 100     
-                           
+                             
+Account: ABC                 
+Participation ID: 123        
+                             
+Vote Key: VEVTVEtFWQ==       
+Selection Key: VEVTVEtFWQ==  
+State Proof Key: VEVTVEtFWQ==
+                             
+Vote First Valid: 0          
+Vote Last Valid: 30000       
+Vote Key Dilution: 100       
+                             

--- a/ui/utils/utils.go
+++ b/ui/utils/utils.go
@@ -7,6 +7,13 @@ import (
 
 func toPtr[T any](constVar T) *T { return &constVar }
 
+func Base64EncodeBytesPtrOrNil(b []byte) *string {
+	if b == nil || len(b) == 0 || isZeros(b) {
+		return nil
+	}
+	return toPtr(base64.StdEncoding.EncodeToString(b))
+}
+
 func UrlEncodeBytesPtrOrNil(b []byte) *string {
 	if b == nil || len(b) == 0 || isZeros(b) {
 		return nil


### PR DESCRIPTION
# ℹ Overview

The key info modal rendered the participation keys with base64url

The expected format is base64 with padding, as goal outputs. This fixes copy-pastability to 3rd party tools that may not support base64url. 

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [ ] Pre-commit checks pass