### PR TITLE
feat: enable incentive eligibility fees

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -162,7 +162,7 @@ var bootstrapCmd = &cobra.Command{
 
 		t := new(system.Clock)
 		// Fetch the state and handle any creation errors
-		state, stateResponse, err := algod.NewStateModel(ctx, client, httpPkg)
+		state, stateResponse, err := algod.NewStateModel(ctx, client, httpPkg, false)
 		cmdutils.WithInvalidResponsesExplanations(err, stateResponse, cmd.UsageString())
 		cobra.CheckErr(err)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,9 @@ var (
 
 	NeedsUpgrade = false
 
+	// whether the user forbids incentive eligibility fees to be set
+	IncentivesDisabled = false
+
 	// algodEndpoint defines the URI address of the Algorand node, including the protocol (http/https), for client communication.
 	algodData string
 
@@ -60,7 +63,7 @@ var (
 			httpPkg := new(api.HttpPkg)
 			t := new(system.Clock)
 			// Fetch the state and handle any creation errors
-			state, stateResponse, err := algod.NewStateModel(ctx, client, httpPkg)
+			state, stateResponse, err := algod.NewStateModel(ctx, client, httpPkg, IncentivesDisabled)
 			utils.WithInvalidResponsesExplanations(err, stateResponse, cmd.UsageString())
 			cobra.CheckErr(err)
 
@@ -127,6 +130,7 @@ func NeedsToBeStopped(cmd *cobra.Command, args []string) {
 // init initializes the application, setting up logging, commands, and version information.
 func init() {
 	log.SetReportTimestamp(false)
+	RootCmd.Flags().BoolVarP(&IncentivesDisabled, "no-incentives", "n", false, style.LightBlue("Disable setting incentive eligibility fees"))
 	RootCmd.SetVersionTemplate(fmt.Sprintf("nodekit-%s-%s@{{.Version}}\n", runtime.GOARCH, runtime.GOOS))
 	// Add Commands
 	if runtime.GOOS != "windows" {

--- a/internal/algod/participation/participation.go
+++ b/internal/algod/participation/participation.go
@@ -167,7 +167,7 @@ func GetOnlineShortLink(http api.HttpPkgInterface, part OnlineShortLinkBody) (Sh
 	if err != nil {
 		return response, err
 	}
-	res, err := http.Post("http://b.nodekit.run/online", "applicaiton/json", bytes.NewReader(data))
+	res, err := http.Post("http://b.nodekit.run/online", "application/json", bytes.NewReader(data))
 	if err != nil {
 		return response, err
 	}
@@ -219,6 +219,10 @@ func GetOfflineShortLink(http api.HttpPkgInterface, offline OfflineShortLinkBody
 
 // ToShortLink generates a shortened URL string using the unique
 // identifier from the provided ShortLinkResponse.
-func ToShortLink(link ShortLinkResponse) string {
-	return fmt.Sprintf("https://b.nodekit.run/%s", link.Id)
+func ToShortLink(link ShortLinkResponse, incentiveEligibleFee bool) string {
+	suffix := ""
+	if incentiveEligibleFee {
+		suffix = "i"
+	}
+	return fmt.Sprintf("https://b.nodekit.run/%s%s", link.Id, suffix)
 }

--- a/internal/algod/state.go
+++ b/internal/algod/state.go
@@ -38,6 +38,9 @@ type StateModel struct {
 	// TODO: handle contexts instead of adding it to state (skill-issue zero)
 	Watching bool
 
+	// Whether user has disabled automatically applying incentive eligibility fees
+	IncentivesDisabled bool
+
 	// Client provides an interface for interacting with API endpoints,
 	// enabling various node operations and data retrieval.
 	Client api.ClientWithResponsesInterface
@@ -53,7 +56,7 @@ type StateModel struct {
 
 // NewStateModel initializes and returns a new StateModel instance
 // along with an API response and potential error.
-func NewStateModel(ctx context.Context, client api.ClientWithResponsesInterface, httpPkg api.HttpPkgInterface) (*StateModel, api.ResponseInterface, error) {
+func NewStateModel(ctx context.Context, client api.ClientWithResponsesInterface, httpPkg api.HttpPkgInterface, incentivesDisabled bool) (*StateModel, api.ResponseInterface, error) {
 	// Preload the node status
 	status, response, err := NewStatus(ctx, client, httpPkg)
 	if err != nil {
@@ -79,6 +82,8 @@ func NewStateModel(ctx context.Context, client api.ClientWithResponsesInterface,
 		Client:  client,
 		HttpPkg: httpPkg,
 		Context: ctx,
+
+		IncentivesDisabled: incentivesDisabled,
 	}, partkeysResponse, nil
 }
 

--- a/internal/algod/status.go
+++ b/internal/algod/status.go
@@ -48,6 +48,9 @@ type Status struct {
 	// NeedsUpdate indicates whether the system requires an update based on the current version and available release data.
 	NeedsUpdate bool `json:"needsUpdate"`
 
+	// LastProtocolVersion represents the most recent round protocol version.
+	LastProtocolVersion string `json:"lastProtocolVersion"`
+
 	// LastRound represents the most recent round number recorded by the system or client.
 	LastRound uint64 `json:"lastRound"`
 
@@ -106,6 +109,9 @@ func (s Status) Update(status Status) Status {
 	if s.LastRound != status.LastRound {
 		s.LastRound = status.LastRound
 	}
+	if s.LastProtocolVersion != status.LastProtocolVersion {
+		s.LastProtocolVersion = status.LastProtocolVersion
+	}
 	return s
 }
 
@@ -127,6 +133,7 @@ func (s Status) Wait(ctx context.Context) (Status, api.ResponseInterface, error)
 // Merge updates the current Status with data from a given StatusLike instance and adjusts fields based on defined conditions.
 func (s Status) Merge(res api.StatusLike) Status {
 	s.LastRound = uint64(res.LastRound)
+	s.LastProtocolVersion = res.LastVersion
 	catchpoint := res.Catchpoint
 	if catchpoint != nil && *catchpoint != "" {
 		s.State = FastCatchupState

--- a/ui/modals/transaction/view.go
+++ b/ui/modals/transaction/view.go
@@ -29,12 +29,23 @@ func (m ViewModel) View() string {
 		adj = "online"
 	}
 	intro := fmt.Sprintf("Sign this transaction to register your account as %s", adj)
-	link := participation.ToShortLink(*m.Link)
+	link := participation.ToShortLink(*m.Link, m.ShouldAddIncentivesFee())
 	loraText := lipgloss.JoinVertical(
 		lipgloss.Center,
 		"Open this URL in your browser:\n",
 		style.WithHyperlink(link, link),
 	)
+
+	if m.ShouldAddIncentivesFee() {
+		loraText = lipgloss.JoinVertical(
+			lipgloss.Center,
+			loraText,
+			"",
+			"Note: Transction fee set to 2 ALGO",
+			"for staking rewards eligibility",
+		)
+	}
+
 	if isOffline {
 		loraText = lipgloss.JoinVertical(
 			lipgloss.Center,


### PR DESCRIPTION
# ℹ Overview

Enables automatic setting of incentive eligibility fees. Users can opt out by running nodekit with `--no-incentives`

Criteria to add the 2A fee:

1) incentives allowed by user - command line flag to disable incentives has _not_ been passed
2) keyreg type if online
3) protocol supports incentives - currently gated to the v4 protocol, can be a list or feature-based in the future.
4) account is not already incentives eligible

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Pre-commit checks pass