### PR TITLE
Docs: Changed doc link on landing page to redirect to new dev portal

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -123,7 +123,7 @@ export const lang = "en";
                         </div>
                         <a
                             class="text-white/80 hover:text-[#BFBFF9]"
-                            href="/guides/getting-started/"
+                            href="https://developer.algorand.co/nodes/nodekit-quick-start"
                             >Guides &amp; Documentation <Icon name="external" />
                         </a>
                     </div>


### PR DESCRIPTION
# ℹ Overview

Updated landing page docs link to point to the new dev portal node running docs (https://developer.algorand.co/nodes/nodekit-quick-start/)

### 📝 Related Issues

<!--
- resolves #1
-->

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [ ] Pre-commit checks pass