### PR TITLE
fix: wait for status from unstable clients

### DIFF
--- a/internal/algod/algod.go
+++ b/internal/algod/algod.go
@@ -145,3 +145,8 @@ func Stop() error {
 		return fmt.Errorf(UnsupportedOSError)
 	}
 }
+
+// IsInitialized determines if the Algod software is installed, configured as a service, and currently running.
+func IsInitialized() bool {
+	return IsInstalled() && IsService() && IsRunning()
+}

--- a/ui/bootstrap/model.go
+++ b/ui/bootstrap/model.go
@@ -2,9 +2,9 @@ package bootstrap
 
 import (
 	"github.com/algorandfoundation/nodekit/ui/app"
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/log"
 )
 
 type Question string
@@ -43,8 +43,17 @@ func NewModel() Model {
 		},
 	}
 }
+
+var termMarkdown *glamour.TermRenderer
+
 func (m Model) Init() tea.Cmd {
-	return textinput.Blink
+	var err error
+	termMarkdown, err = glamour.NewTermRenderer(glamour.WithAutoStyle())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return nil
 }
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
@@ -95,13 +104,6 @@ func (m Model) View() string {
 	case CatchupQuestion:
 		str = CatchupQuestionMsg
 	}
-	var msg string
-	r, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
-	if err != nil {
-		// Fallback to dark mode
-		msg, _ = glamour.Render(str, "dark")
-	} else {
-		msg, _ = r.Render(str)
-	}
-	return msg
+	str, _ = termMarkdown.Render(str)
+	return str
 }


### PR DESCRIPTION
# ℹ Overview

Resolves the case when fast-catchup fails due to the node being inaccessible during bootstrap.

- adds wait for client interface
- ensures the service is active before trying to access the node
- uses parameters for fast catchup

### ✅ Acceptance:

- [X] Pre-commit checks pass