### PR TITLE
Feat: installer env vars enabling unattended installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,8 @@ prompt_default_no() {
 
 if [ -f nodekit ]; then
   warn "A nodekit file already exists in the current directory."
-  if prompt_default_no "Do you want to upgrade it to the latest nodekit?"; then
+  # Set the NODEKIT_FORCE_INSTALL environment variable to anything in order to force upgrading nodekit without prompting
+  if [[ -n "${NODEKIT_FORCE_INSTALL-}" ]] || prompt_default_no "Do you want to upgrade it to the latest nodekit?"; then
     rm nodekit
   else
     info "Not upgrading nodekit.\n\nYou can run nodekit with:\n\n./nodekit\n\nOr start the installer with:\n\n./nodekit bootstrap"
@@ -103,8 +104,12 @@ trap - exit
 success "Downloaded: ${Bold_Green}${target} as nodekit 🎉${Reset}"
 info "Explore all nodekit options with:"
 echo "./nodekit --help"
-echo ""
-info "Starting nodekit bootstrap"
-echo "./nodekit bootstrap"
 
-./nodekit bootstrap
+# Set the NODEKIT_SKIP_BOOTSTRAP environment variable to anything in order to skip bootstrap
+# Useful for non-interactive setup
+if [[ -z "${NODEKIT_SKIP_BOOTSTRAP-}" ]]; then
+  echo ""
+  info "Starting nodekit bootstrap"
+  echo "./nodekit bootstrap"
+  ./nodekit bootstrap
+fi

--- a/unattended.sh
+++ b/unattended.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Install nodekit, replacing any previous nodekit (FORCE_INSTALL) and skipping the interactive bootstrap
+wget -qO- https://nodekit.run/install.sh | NODEKIT_FORCE_INSTALL=1 NODEKIT_SKIP_BOOTSTRAP=1 bash
+
+# Install node
+./nodekit install -f
+
+# Wait a bit for connections to be established
+sleep 2m
+
+# Start a fast catchup
+./nodekit catchup start


### PR DESCRIPTION
# ℹ Overview

Introduces the `NODEKIT_FORCE_INSTALL` and `NODEKIT_SKIP_BOOTSTRAP` environment variables to the installer. These are considered enabled if they are set to any non-zero-length string.

`NODEKIT_FORCE_INSTALL` - replace existing nodekit without prompting
`NODEKIT_SKIP_BOOTSTRAP` - skip the final bootstrap step 

The two can be used to script an unattended installation of nodekit, e.g. with:

`wget -qO- https://nodekit.run/install.sh | NODEKIT_FORCE_INSTALL=1 NODEKIT_SKIP_BOOTSTRAP=1 bash`

Example usage has been added under `unattended.sh`

### 📝 Related Issues

<!--
- resolves #1
-->

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Pre-commit checks pass