### PR TITLE
Docs: telemetry changes

### DIFF
--- a/cmd/telemetry/disable/disable.go
+++ b/cmd/telemetry/disable/disable.go
@@ -15,7 +15,7 @@ var Long = lipgloss.JoinVertical(
 	style.Bold(Short),
 	"",
 	style.BoldUnderline("Overview:"),
-	"Configure telemetry for the Algorand daemon.",
+	"Disable telemetry for the Algorand daemon.",
 	"",
 	style.Yellow.Render(explanations.ExperimentalWarning),
 )

--- a/cmd/telemetry/enable/enable.go
+++ b/cmd/telemetry/enable/enable.go
@@ -15,7 +15,7 @@ var Long = lipgloss.JoinVertical(
 	style.Bold(Short),
 	"",
 	style.BoldUnderline("Overview:"),
-	"Configure telemetry for the Algorand daemon.",
+	"Enable a telemetry profile for the Algorand daemon.",
 	"",
 	style.Yellow.Render(explanations.ExperimentalWarning),
 )

--- a/cmd/telemetry/enable/nodely.go
+++ b/cmd/telemetry/enable/nodely.go
@@ -43,7 +43,9 @@ Enabling telemetry will configure your node to send health metrics to Nodely
 
 > Tip: Keep this GUID identifier private if you do not want this information to be linked to your identity.
 
-**Do you want to enable telemetry with the nodely provider? (y/n)**
+Nodely Telemetry Documentation: https://nodely.io/docs/public/telemetry/
+
+**Do you want to enable telemetry with the Nodely provider? (y/n)**
 `
 
 var nodelyCmd = cmdutils.WithAlgodFlags(&cobra.Command{

--- a/cmd/telemetry/enable/nodely.go
+++ b/cmd/telemetry/enable/nodely.go
@@ -14,7 +14,7 @@ import (
 	"os"
 )
 
-var nodelyShort = "Disable Nodely"
+var nodelyShort = "Disable telemetry"
 var nodelyLong = lipgloss.JoinVertical(
 	lipgloss.Left,
 	style.Purple(style.BANNER),
@@ -22,7 +22,7 @@ var nodelyLong = lipgloss.JoinVertical(
 	style.Bold(nodelyShort),
 	"",
 	style.BoldUnderline("Overview:"),
-	"Configure telemetry for the Algorand daemon.",
+	"Enable the Nodely telemetry profile for the Algorand daemon.",
 	"",
 	style.Yellow.Render(explanations.ExperimentalWarning),
 )

--- a/cmd/telemetry/enable/nodely.go
+++ b/cmd/telemetry/enable/nodely.go
@@ -14,7 +14,7 @@ import (
 	"os"
 )
 
-var nodelyShort = "Disable telemetry"
+var nodelyShort = "Enable Nodely telemetry profile"
 var nodelyLong = lipgloss.JoinVertical(
 	lipgloss.Left,
 	style.Purple(style.BANNER),

--- a/cmd/telemetry/status.go
+++ b/cmd/telemetry/status.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var statusShort = "Status of telemetry"
+var statusShort = "Telemetry status"
 
 var statusLong = lipgloss.JoinVertical(
 	lipgloss.Left,
@@ -20,7 +20,7 @@ var statusLong = lipgloss.JoinVertical(
 	style.Bold(statusShort),
 	"",
 	style.BoldUnderline("Overview:"),
-	"Configure telemetry for the Algorand daemon.",
+	"Display telemetry profile status for the Algorand daemon.",
 	"",
 	style.Yellow.Render(explanations.ExperimentalWarning),
 )

--- a/cmd/telemetry/status.go
+++ b/cmd/telemetry/status.go
@@ -61,9 +61,11 @@ var statusCmd = cmdutils.WithAlgodFlags(&cobra.Command{
 				fmt.Sprintf("Telemetry GUID: %s", config.GUID),
 				fmt.Sprintf("Telemetry Endpoint: %s", config.URI),
 			}...)
-
+			if config.Enable && config.URI == string(cmdutils.NodelyTelemetryProvider) {
+				msgs = append(msgs, fmt.Sprintf("Nodely Dashboard URL: https://g.nodely.io/d/telemetry/node-telemetry?var-GUID=%s", config.GUID))
+			}
 		} else {
-			msgs = append(msgs, fmt.Sprintf("You can enable nodely telemetry with %s", style.Bold("nodekit telemetry enable nodely")))
+			msgs = append(msgs, fmt.Sprintf("You can enable telemetry profiles with %s", style.Bold("nodekit telemetry enable")))
 		}
 
 		cmd.Println(lipgloss.JoinVertical(

--- a/cmd/telemetry/telemetry.go
+++ b/cmd/telemetry/telemetry.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Short = "NoOp command"
+var Short = "Configure telemetry profile"
 var Long = lipgloss.JoinVertical(
 	lipgloss.Left,
 	style.Purple(style.BANNER),
@@ -16,7 +16,7 @@ var Long = lipgloss.JoinVertical(
 	style.Bold(Short),
 	"",
 	style.BoldUnderline("Overview:"),
-	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	"Enable, disable and view telemetry status.",
 	"",
 )
 


### PR DESCRIPTION
- fix help strings
- `telemetry status` to show dashboard URL if profile matches nodely
- added nodely telemetry docs to `telemetry enable nodely`