### PR TITLE
fix: debug: fix small token (less than 3 chars) causing panic

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -90,7 +90,7 @@ var debugCmd = cmdutils.WithAlgodFlags(&cobra.Command{
 		folderDebug, err := utils.ToDataFolderConfig(dataDir)
 		if err != nil {
 			folderDebug.Token = fmt.Sprint(err)
-		} else {
+		} else if len(folderDebug.Token) > 3 {
 			folderDebug.Token = folderDebug.Token[:3] + "..."
 		}
 


### PR DESCRIPTION
# ℹ Overview

algod admin token smaller than 3 characters (including empty file) causes panic

### 📝 Related Issues

- resolves #162

### ✅ Acceptance:

- [x] Pre-commit checks pass