### PR TITLE
fix: install: error when an algorand user exists

### DIFF
--- a/internal/algod/linux/linux.go
+++ b/internal/algod/linux/linux.go
@@ -64,7 +64,7 @@ func InstallRequirements() system.CmdsList {
 // Install installs Algorand development tools or node software depending on the package manager.
 func Install() error {
 	if hasConflictingUser() {
-		log.Fatal("Your system has a user called \"algorand\". The algorand node requires the \"algorand\" username for internal usage. Rename or remove the algorand user to continue.")
+		return fmt.Errorf("Your system has a user called \"algorand\". The algorand node requires the \"algorand\" username for internal usage. Rename or remove the algorand user to continue.")
 	}
 
 	log.Info("Installing Algod on Linux")

--- a/internal/algod/linux/linux.go
+++ b/internal/algod/linux/linux.go
@@ -26,18 +26,18 @@ type Algod struct {
 	DataDirectoryPath string
 }
 
-func CheckConflictingUser() {
+func hasConflictingUser() bool {
 	if runtime.GOOS != "linux" {
-		return
+		return false
 	}
 	algorandUser, _ := user.Lookup("algorand")
 	if algorandUser != nil {
 		uid, _ := strconv.Atoi(algorandUser.Uid)
 		if uid >= 1000 {
-			log.Error("Your system has a user called \"algorand\". The algorand node requires the \"algorand\" username for internal usage.\nRename or remove the algorand user to continue.")
-			os.Exit(1)
+			return true
 		}
 	}
+	return false
 }
 
 // InstallRequirements generates installation commands for "sudo" based on the detected package manager and system state.
@@ -63,7 +63,9 @@ func InstallRequirements() system.CmdsList {
 
 // Install installs Algorand development tools or node software depending on the package manager.
 func Install() error {
-	CheckConflictingUser()
+	if hasConflictingUser() {
+		log.Fatal("Your system has a user called \"algorand\". The algorand node requires the \"algorand\" username for internal usage. Rename or remove the algorand user to continue.")
+	}
 
 	log.Info("Installing Algod on Linux")
 


### PR DESCRIPTION
# ℹ Overview

- detect & error when an `algorand` user exists (with PID >= 1000 i.e. a user-level user, vs. the system-level user we expect which would be < 1000) 

### 📝 Related Issues

- resolves #71 

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Pre-commit checks pass