### PR TITLE
chore: enable telemetry: show hint for dashboard URL

### DIFF
--- a/cmd/telemetry/enable/nodely.go
+++ b/cmd/telemetry/enable/nodely.go
@@ -85,6 +85,8 @@ var nodelyCmd = cmdutils.WithAlgodFlags(&cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
+
+			log.Info("Telemetry enabled. To see your Nodely dashboard URL, run:\n    ./nodekit telemetry status")
 		}
 	},
 }, &dataDir)


### PR DESCRIPTION
# ℹ Overview

Added this message after enabling nodely telemetry profile:

```
INFO Telemetry enabled. To find your Nodely dashboard URL, run:
    ./nodekit telemetry status
```

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [ ] Pre-commit checks pass